### PR TITLE
Implement secret rotation reminders feature

### DIFF
--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -688,7 +688,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
       secretKeyCiphertext,
       skipMultilineEncoding,
       rotationReminderEnabled,
-      rotationReminderInterval
+      reminderIntervalInDays
     },
     params: { secretName }
   } = await validateRequest(reqValidator.UpdateSecretByNameV3, req);
@@ -729,7 +729,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
               secretCommentCiphertext,
               skipMultilineEncoding,
               rotationReminderEnabled,
-              rotationReminderInterval,
+              reminderIntervalInDays,
               secretKeyTag,
               secretKeyCiphertext,
               secretKeyIV
@@ -759,7 +759,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
     secretCommentCiphertext,
     skipMultilineEncoding,
     rotationReminderEnabled,
-    rotationReminderInterval,
+    reminderIntervalInDays,
     secretKeyTag,
     secretKeyCiphertext,
     secretKeyIV

--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -688,7 +688,8 @@ export const updateSecretByName = async (req: Request, res: Response) => {
       secretKeyCiphertext,
       skipMultilineEncoding,
       rotationReminderEnabled,
-      reminderIntervalInDays
+      reminderIntervalInDays,
+      reminderNotes
     },
     params: { secretName }
   } = await validateRequest(reqValidator.UpdateSecretByNameV3, req);
@@ -730,6 +731,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
               skipMultilineEncoding,
               rotationReminderEnabled,
               reminderIntervalInDays,
+              reminderNotes,
               secretKeyTag,
               secretKeyCiphertext,
               secretKeyIV
@@ -760,6 +762,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
     skipMultilineEncoding,
     rotationReminderEnabled,
     reminderIntervalInDays,
+    reminderNotes,
     secretKeyTag,
     secretKeyCiphertext,
     secretKeyIV

--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -687,7 +687,8 @@ export const updateSecretByName = async (req: Request, res: Response) => {
       secretKeyTag,
       secretKeyCiphertext,
       skipMultilineEncoding,
-      rotationReminderEnabled
+      rotationReminderEnabled,
+      rotationReminderInterval
     },
     params: { secretName }
   } = await validateRequest(reqValidator.UpdateSecretByNameV3, req);
@@ -728,6 +729,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
               secretCommentCiphertext,
               skipMultilineEncoding,
               rotationReminderEnabled,
+              rotationReminderInterval,
               secretKeyTag,
               secretKeyCiphertext,
               secretKeyIV
@@ -757,6 +759,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
     secretCommentCiphertext,
     skipMultilineEncoding,
     rotationReminderEnabled,
+    rotationReminderInterval,
     secretKeyTag,
     secretKeyCiphertext,
     secretKeyIV

--- a/backend/src/controllers/v3/secretsController.ts
+++ b/backend/src/controllers/v3/secretsController.ts
@@ -686,7 +686,8 @@ export const updateSecretByName = async (req: Request, res: Response) => {
       secretKeyIV,
       secretKeyTag,
       secretKeyCiphertext,
-      skipMultilineEncoding
+      skipMultilineEncoding,
+      rotationReminderEnabled
     },
     params: { secretName }
   } = await validateRequest(reqValidator.UpdateSecretByNameV3, req);
@@ -726,6 +727,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
               secretCommentTag,
               secretCommentCiphertext,
               skipMultilineEncoding,
+              rotationReminderEnabled,
               secretKeyTag,
               secretKeyCiphertext,
               secretKeyIV
@@ -754,6 +756,7 @@ export const updateSecretByName = async (req: Request, res: Response) => {
     secretCommentTag,
     secretCommentCiphertext,
     skipMultilineEncoding,
+    rotationReminderEnabled,
     secretKeyTag,
     secretKeyCiphertext,
     secretKeyIV

--- a/backend/src/ee/models/secretApprovalRequest.ts
+++ b/backend/src/ee/models/secretApprovalRequest.ts
@@ -36,6 +36,7 @@ export interface ISecretApprovalSecChange {
   secretCommentCiphertext?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   algorithm?: "aes-256-gcm";
   keyEncoding?: "utf8" | "base64";
   tags?: string[];
@@ -119,6 +120,10 @@ const secretApprovalSecretChangeSchema = new Schema<ISecretApprovalSecChange>({
   },
   rotationReminderEnabled: {
     type: Boolean,
+    required: false
+  },
+  rotationReminderInterval: {
+    type: Number,
     required: false
   },
   algorithm: {

--- a/backend/src/ee/models/secretApprovalRequest.ts
+++ b/backend/src/ee/models/secretApprovalRequest.ts
@@ -36,7 +36,7 @@ export interface ISecretApprovalSecChange {
   secretCommentCiphertext?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   algorithm?: "aes-256-gcm";
   keyEncoding?: "utf8" | "base64";
   tags?: string[];
@@ -122,7 +122,7 @@ const secretApprovalSecretChangeSchema = new Schema<ISecretApprovalSecChange>({
     type: Boolean,
     required: false
   },
-  rotationReminderInterval: {
+  reminderIntervalInDays: {
     type: Number,
     required: false
   },

--- a/backend/src/ee/models/secretApprovalRequest.ts
+++ b/backend/src/ee/models/secretApprovalRequest.ts
@@ -35,6 +35,7 @@ export interface ISecretApprovalSecChange {
   secretCommentTag?: string;
   secretCommentCiphertext?: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   algorithm?: "aes-256-gcm";
   keyEncoding?: "utf8" | "base64";
   tags?: string[];
@@ -113,6 +114,10 @@ const secretApprovalSecretChangeSchema = new Schema<ISecretApprovalSecChange>({
     required: true
   },
   skipMultilineEncoding: {
+    type: Boolean,
+    required: false
+  },
+  rotationReminderEnabled: {
     type: Boolean,
     required: false
   },

--- a/backend/src/ee/models/secretApprovalRequest.ts
+++ b/backend/src/ee/models/secretApprovalRequest.ts
@@ -37,6 +37,7 @@ export interface ISecretApprovalSecChange {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   algorithm?: "aes-256-gcm";
   keyEncoding?: "utf8" | "base64";
   tags?: string[];
@@ -124,6 +125,10 @@ const secretApprovalSecretChangeSchema = new Schema<ISecretApprovalSecChange>({
   },
   reminderIntervalInDays: {
     type: Number,
+    required: false
+  },
+  reminderNotes: {
+    type: String,
     required: false
   },
   algorithm: {

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -26,6 +26,7 @@ export interface ISecretVersion {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   createdAt: string;
@@ -109,6 +110,10 @@ const secretVersionSchema = new Schema<ISecretVersion>(
     },
     reminderIntervalInDays: {
       type: Number,
+      required: false
+    },
+    reminderNotes: {
+      type: String,
       required: false
     },
     algorithm: {

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -25,6 +25,7 @@ export interface ISecretVersion {
   secretValueTag: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   createdAt: string;
@@ -104,6 +105,10 @@ const secretVersionSchema = new Schema<ISecretVersion>(
     },
     rotationReminderEnabled: {
       type: Boolean,
+      required: false
+    },
+    rotationReminderInterval: {
+      type: Number,
       required: false
     },
     algorithm: {

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -24,6 +24,7 @@ export interface ISecretVersion {
   secretValueIV: string;
   secretValueTag: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   createdAt: string;
@@ -98,6 +99,10 @@ const secretVersionSchema = new Schema<ISecretVersion>(
       required: true
     },
     skipMultilineEncoding: {
+      type: Boolean,
+      required: false
+    },
+    rotationReminderEnabled: {
       type: Boolean,
       required: false
     },

--- a/backend/src/ee/models/secretVersion.ts
+++ b/backend/src/ee/models/secretVersion.ts
@@ -25,7 +25,7 @@ export interface ISecretVersion {
   secretValueTag: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   createdAt: string;
@@ -107,7 +107,7 @@ const secretVersionSchema = new Schema<ISecretVersion>(
       type: Boolean,
       required: false
     },
-    rotationReminderInterval: {
+    reminderIntervalInDays: {
       type: Number,
       required: false
     },

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -54,6 +54,7 @@ import { getFolderByPath, getFolderIdFromServiceToken } from "../services/Folder
 import picomatch from "picomatch";
 import path from "path";
 import { getAnImportedSecret } from "../services/SecretImportService";
+import { addAllProjectMembersReminder, removeAllProjectMembersReminder } from "../queues/secret-rotation-reminders/remindAllProjectMembers";
 
 /**
  * Validate scope for service token v3
@@ -821,16 +822,16 @@ export const updateSecretHelper = async ({
     salt
   });
 
+  let oldSecret;
   if (secretId) {
-    const secret = await Secret.findOne({
+    oldSecret = await Secret.findOne({
       workspace: workspaceId,
       environment,
       _id: secretId
-    }).select("secretBlindIndex");
-    if (secret && secret.secretBlindIndex) oldSecretBlindIndex = secret.secretBlindIndex;
+    }).select("secretBlindIndex rotationReminderEnabled");
+    if (oldSecret && oldSecret.secretBlindIndex) oldSecretBlindIndex = oldSecret.secretBlindIndex;
   }
 
-  let secret: ISecret | null = null;
   const folderId = await getFolderIdFromServiceToken(workspaceId, environment, secretPath);
 
   let newSecretNameBlindIndex = undefined;
@@ -852,6 +853,7 @@ export const updateSecretHelper = async ({
     }
   }
 
+  let secret: ISecret | null = null;
   if (type === SECRET_SHARED) {
     // case: update shared secret
     secret = await Secret.findOneAndUpdate(
@@ -1007,6 +1009,23 @@ export const updateSecretHelper = async ({
         userAgent: authData.userAgent
       }
     });
+  }
+
+  if (oldSecret && oldSecret.rotationReminderEnabled !== rotationReminderEnabled && reminderIntervalInDays) {
+    const repeatOpts = {
+      every: reminderIntervalInDays * 1000,
+      secretId: oldSecret._id
+    }
+    if (rotationReminderEnabled) {
+      await addAllProjectMembersReminder({
+        intervalDays: reminderIntervalInDays,
+        note: reminderNotes,
+        secretId: oldSecret._id,
+        workspaceId
+      }, repeatOpts)
+    } else {
+      await removeAllProjectMembersReminder(repeatOpts)
+    }
   }
 
   return secret;

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -806,7 +806,8 @@ export const updateSecretHelper = async ({
   secretCommentCiphertext,
   secretCommentIV,
   secretCommentTag,
-  skipMultilineEncoding
+  skipMultilineEncoding,
+  rotationReminderEnabled
 }: UpdateSecretParams) => {
   // get secret blind index salt
   const salt = await getSecretBlindIndexSaltHelper({
@@ -867,6 +868,7 @@ export const updateSecretHelper = async ({
         secretCommentTag,
         secretCommentCiphertext,
         skipMultilineEncoding,
+        rotationReminderEnabled,
         secretBlindIndex: newSecretNameBlindIndex,
         secretKeyIV,
         secretKeyTag,
@@ -899,6 +901,7 @@ export const updateSecretHelper = async ({
         secretKeyCiphertext,
         tags,
         skipMultilineEncoding,
+        rotationReminderEnabled,
         secretBlindIndex: newSecretNameBlindIndex,
         $inc: { version: 1 }
       },
@@ -928,6 +931,7 @@ export const updateSecretHelper = async ({
     secretValueIV,
     secretValueTag,
     skipMultilineEncoding,
+    rotationReminderEnabled,
     algorithm: ALGORITHM_AES_256_GCM,
     keyEncoding: ENCODING_SCHEME_UTF8
   });

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -807,7 +807,8 @@ export const updateSecretHelper = async ({
   secretCommentIV,
   secretCommentTag,
   skipMultilineEncoding,
-  rotationReminderEnabled
+  rotationReminderEnabled,
+  rotationReminderInterval
 }: UpdateSecretParams) => {
   // get secret blind index salt
   const salt = await getSecretBlindIndexSaltHelper({
@@ -869,6 +870,7 @@ export const updateSecretHelper = async ({
         secretCommentCiphertext,
         skipMultilineEncoding,
         rotationReminderEnabled,
+        rotationReminderInterval,
         secretBlindIndex: newSecretNameBlindIndex,
         secretKeyIV,
         secretKeyTag,
@@ -902,6 +904,7 @@ export const updateSecretHelper = async ({
         tags,
         skipMultilineEncoding,
         rotationReminderEnabled,
+        rotationReminderInterval,
         secretBlindIndex: newSecretNameBlindIndex,
         $inc: { version: 1 }
       },
@@ -932,6 +935,7 @@ export const updateSecretHelper = async ({
     secretValueTag,
     skipMultilineEncoding,
     rotationReminderEnabled,
+    rotationReminderInterval,
     algorithm: ALGORITHM_AES_256_GCM,
     keyEncoding: ENCODING_SCHEME_UTF8
   });

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -1013,7 +1013,7 @@ export const updateSecretHelper = async ({
 
   if (oldSecret && oldSecret.rotationReminderEnabled !== rotationReminderEnabled && reminderIntervalInDays) {
     const repeatOpts = {
-      every: reminderIntervalInDays * 1000,
+      every: reminderIntervalInDays * 24 * 60 * 60 * 1000,
       secretId: oldSecret._id
     }
     if (rotationReminderEnabled) {

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -808,7 +808,7 @@ export const updateSecretHelper = async ({
   secretCommentTag,
   skipMultilineEncoding,
   rotationReminderEnabled,
-  rotationReminderInterval
+  reminderIntervalInDays
 }: UpdateSecretParams) => {
   // get secret blind index salt
   const salt = await getSecretBlindIndexSaltHelper({
@@ -870,7 +870,7 @@ export const updateSecretHelper = async ({
         secretCommentCiphertext,
         skipMultilineEncoding,
         rotationReminderEnabled,
-        rotationReminderInterval,
+        reminderIntervalInDays,
         secretBlindIndex: newSecretNameBlindIndex,
         secretKeyIV,
         secretKeyTag,
@@ -904,7 +904,7 @@ export const updateSecretHelper = async ({
         tags,
         skipMultilineEncoding,
         rotationReminderEnabled,
-        rotationReminderInterval,
+        reminderIntervalInDays,
         secretBlindIndex: newSecretNameBlindIndex,
         $inc: { version: 1 }
       },
@@ -935,7 +935,7 @@ export const updateSecretHelper = async ({
     secretValueTag,
     skipMultilineEncoding,
     rotationReminderEnabled,
-    rotationReminderInterval,
+    reminderIntervalInDays,
     algorithm: ALGORITHM_AES_256_GCM,
     keyEncoding: ENCODING_SCHEME_UTF8
   });

--- a/backend/src/helpers/secrets.ts
+++ b/backend/src/helpers/secrets.ts
@@ -808,7 +808,8 @@ export const updateSecretHelper = async ({
   secretCommentTag,
   skipMultilineEncoding,
   rotationReminderEnabled,
-  reminderIntervalInDays
+  reminderIntervalInDays,
+  reminderNotes
 }: UpdateSecretParams) => {
   // get secret blind index salt
   const salt = await getSecretBlindIndexSaltHelper({
@@ -871,6 +872,7 @@ export const updateSecretHelper = async ({
         skipMultilineEncoding,
         rotationReminderEnabled,
         reminderIntervalInDays,
+        reminderNotes,
         secretBlindIndex: newSecretNameBlindIndex,
         secretKeyIV,
         secretKeyTag,
@@ -905,6 +907,7 @@ export const updateSecretHelper = async ({
         skipMultilineEncoding,
         rotationReminderEnabled,
         reminderIntervalInDays,
+        reminderNotes,
         secretBlindIndex: newSecretNameBlindIndex,
         $inc: { version: 1 }
       },
@@ -936,6 +939,7 @@ export const updateSecretHelper = async ({
     skipMultilineEncoding,
     rotationReminderEnabled,
     reminderIntervalInDays,
+    reminderNotes,
     algorithm: ALGORITHM_AES_256_GCM,
     keyEncoding: ENCODING_SCHEME_UTF8
   });

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -61,6 +61,7 @@ export interface UpdateSecretParams {
   secretCommentTag?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   tags?: string[];
 }
 

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -60,6 +60,7 @@ export interface UpdateSecretParams {
   secretCommentIV?: string;
   secretCommentTag?: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   tags?: string[];
 }
 

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -62,6 +62,7 @@ export interface UpdateSecretParams {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   tags?: string[];
 }
 

--- a/backend/src/interfaces/services/SecretService/index.ts
+++ b/backend/src/interfaces/services/SecretService/index.ts
@@ -61,7 +61,7 @@ export interface UpdateSecretParams {
   secretCommentTag?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   tags?: string[];
 }
 

--- a/backend/src/models/secret.ts
+++ b/backend/src/models/secret.ts
@@ -28,6 +28,7 @@ export interface ISecret {
   secretCommentTag?: string;
   secretCommentHash?: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   tags?: string[];
@@ -119,6 +120,10 @@ const secretSchema = new Schema<ISecret>(
       required: false
     },
     skipMultilineEncoding: {
+      type: Boolean,
+      required: false
+    },
+    rotationReminderEnabled: {
       type: Boolean,
       required: false
     },

--- a/backend/src/models/secret.ts
+++ b/backend/src/models/secret.ts
@@ -30,6 +30,7 @@ export interface ISecret {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   tags?: string[];
@@ -130,6 +131,10 @@ const secretSchema = new Schema<ISecret>(
     },
     reminderIntervalInDays: {
       type: Number,
+      required: false
+    },
+    reminderNotes: {
+      type: String,
       required: false
     },
     algorithm: {

--- a/backend/src/models/secret.ts
+++ b/backend/src/models/secret.ts
@@ -29,6 +29,7 @@ export interface ISecret {
   secretCommentHash?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   tags?: string[];
@@ -125,6 +126,10 @@ const secretSchema = new Schema<ISecret>(
     },
     rotationReminderEnabled: {
       type: Boolean,
+      required: false
+    },
+    rotationReminderInterval: {
+      type: Number,
       required: false
     },
     algorithm: {

--- a/backend/src/models/secret.ts
+++ b/backend/src/models/secret.ts
@@ -29,7 +29,7 @@ export interface ISecret {
   secretCommentHash?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   algorithm: "aes-256-gcm";
   keyEncoding: "utf8" | "base64";
   tags?: string[];
@@ -128,7 +128,7 @@ const secretSchema = new Schema<ISecret>(
       type: Boolean,
       required: false
     },
-    rotationReminderInterval: {
+    reminderIntervalInDays: {
       type: Number,
       required: false
     },

--- a/backend/src/queues/secret-rotation-reminders/remindAllProjectMembers.ts
+++ b/backend/src/queues/secret-rotation-reminders/remindAllProjectMembers.ts
@@ -24,7 +24,7 @@ allProjectMembersReminders.process("reminder", async (job: Job, done: Queue.Done
 
     const userEmailObjs = await User.find({
       _id: {
-        $in: projectMembersWithUsersIds
+        $in: [...projectMembersWithUsersIds.map(memberWithUserId => memberWithUserId.user)]
       }
     }).select("email").lean();
     

--- a/backend/src/queues/secret-rotation-reminders/remindAllProjectMembers.ts
+++ b/backend/src/queues/secret-rotation-reminders/remindAllProjectMembers.ts
@@ -1,0 +1,67 @@
+import { Types } from "mongoose";
+import Queue, { Job } from "bull";
+import TelemetryService from "../../services/TelemetryService";
+import { Membership } from "../../models/membership";
+import { User } from "../../models/user";
+import { sendMail } from "../../helpers";
+
+export const allProjectMembersReminders = new Queue("all-project-members-secret-rotation-reminders", "redis://redis:6379");
+
+type TSecretRotationReminderDetails = {
+  intervalDays: number;
+  note?: string;
+  secretId: Types.ObjectId;
+  workspaceId: Types.ObjectId;
+}
+
+allProjectMembersReminders.process("reminder", async (job: Job, done: Queue.DoneCallback) => {
+  const { note, workspaceId, secretId }: TSecretRotationReminderDetails = job.data
+
+  try {
+    const projectMembersWithUsersIds = await Membership.find({
+      workspace: workspaceId
+    }).select("user");
+
+    const userEmailObjs = await User.find({
+      _id: {
+        $in: projectMembersWithUsersIds
+      }
+    }).select("email").lean();
+    
+    const userEmails = userEmailObjs.map(userEmailObj => userEmailObj.email);
+
+    await sendMail({
+      template: "secretRotationReminder.handlebars",
+      subjectLine: "Reminder: rotate secret",
+      recipients: userEmails,
+      substitutions: {
+        note
+      }
+    });
+
+    const postHogClient = await TelemetryService.getPostHogClient();
+    if (postHogClient) {
+      postHogClient.capture({
+        event: "Secret rotation reminder emails sent",
+        distinctId: secretId,
+        properties: {
+          userEmails,
+          note
+        }
+      });
+    }
+
+    done(null, { userEmails, note })
+  } catch (err) {
+    done(new Error(`allProjectMembersSecretRotationReminders.process: an error occurred ${err}`), null)
+  }
+});
+
+export const addAllProjectMembersReminder = async (secretRotationReminderPayload: TSecretRotationReminderDetails, repeatOpts: any) => {
+  const job = await allProjectMembersReminders.add("reminder", secretRotationReminderPayload, {
+    repeat: repeatOpts
+  })
+  return job
+};
+
+export const removeAllProjectMembersReminder = async (repeatOpts: any) => await allProjectMembersReminders.removeRepeatable("reminder", repeatOpts)

--- a/backend/src/templates/secretRotationReminder.handlebars
+++ b/backend/src/templates/secretRotationReminder.handlebars
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Reminder: rotate secret</title>
+</head>
+
+<body>
+  <h3>You have received a secret rotation reminder with the following note:</h3>
+  <p>{{note}}</p>
+</body>
+
+</html>

--- a/backend/src/validation/secrets.ts
+++ b/backend/src/validation/secrets.ts
@@ -366,6 +366,7 @@ export const UpdateSecretByNameV3 = z.object({
     skipMultilineEncoding: z.boolean().optional(),
     rotationReminderEnabled: z.boolean().optional(),
     reminderIntervalInDays: z.number().optional(),
+    reminderNotes: z.string().trim().optional(),
     // to update secret name
     secretName: z.string().trim().optional(),
     secretKeyIV: z.string().trim().optional(),

--- a/backend/src/validation/secrets.ts
+++ b/backend/src/validation/secrets.ts
@@ -365,6 +365,7 @@ export const UpdateSecretByNameV3 = z.object({
     tags: z.string().array().optional(),
     skipMultilineEncoding: z.boolean().optional(),
     rotationReminderEnabled: z.boolean().optional(),
+    rotationReminderInterval: z.number().optional(),
     // to update secret name
     secretName: z.string().trim().optional(),
     secretKeyIV: z.string().trim().optional(),

--- a/backend/src/validation/secrets.ts
+++ b/backend/src/validation/secrets.ts
@@ -364,6 +364,7 @@ export const UpdateSecretByNameV3 = z.object({
     secretCommentTag: z.string().trim().optional(),
     tags: z.string().array().optional(),
     skipMultilineEncoding: z.boolean().optional(),
+    rotationReminderEnabled: z.boolean().optional(),
     // to update secret name
     secretName: z.string().trim().optional(),
     secretKeyIV: z.string().trim().optional(),

--- a/backend/src/validation/secrets.ts
+++ b/backend/src/validation/secrets.ts
@@ -365,7 +365,7 @@ export const UpdateSecretByNameV3 = z.object({
     tags: z.string().array().optional(),
     skipMultilineEncoding: z.boolean().optional(),
     rotationReminderEnabled: z.boolean().optional(),
-    rotationReminderInterval: z.number().optional(),
+    reminderIntervalInDays: z.number().optional(),
     // to update secret name
     secretName: z.string().trim().optional(),
     secretKeyIV: z.string().trim().optional(),

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -142,7 +142,8 @@ export const useUpdateSecretV3 = ({
       newSecretName,
       skipMultilineEncoding,
       rotationReminderEnabled,
-      reminderIntervalInDays
+      reminderIntervalInDays,
+      reminderNotes
     }) => {
       const PRIVATE_KEY = localStorage.getItem("PRIVATE_KEY") as string;
 
@@ -166,7 +167,8 @@ export const useUpdateSecretV3 = ({
         skipMultilineEncoding,
         secretName: newSecretName,
         rotationReminderEnabled,
-        reminderIntervalInDays
+        reminderIntervalInDays,
+        reminderNotes
       };
       const { data } = await apiRequest.patch(`/api/v3/secrets/${secretName}`, reqBody);
       return data;

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -140,7 +140,8 @@ export const useUpdateSecretV3 = ({
       tags,
       secretComment,
       newSecretName,
-      skipMultilineEncoding
+      skipMultilineEncoding,
+      rotationReminderEnabled
     }) => {
       const PRIVATE_KEY = localStorage.getItem("PRIVATE_KEY") as string;
 
@@ -162,7 +163,8 @@ export const useUpdateSecretV3 = ({
         ...encryptSecret(randomBytes, newSecretName ?? secretName, secretValue, secretComment),
         tags,
         skipMultilineEncoding,
-        secretName: newSecretName
+        secretName: newSecretName,
+        rotationReminderEnabled
       };
       const { data } = await apiRequest.patch(`/api/v3/secrets/${secretName}`, reqBody);
       return data;

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -141,7 +141,8 @@ export const useUpdateSecretV3 = ({
       secretComment,
       newSecretName,
       skipMultilineEncoding,
-      rotationReminderEnabled
+      rotationReminderEnabled,
+      rotationReminderInterval
     }) => {
       const PRIVATE_KEY = localStorage.getItem("PRIVATE_KEY") as string;
 
@@ -164,7 +165,8 @@ export const useUpdateSecretV3 = ({
         tags,
         skipMultilineEncoding,
         secretName: newSecretName,
-        rotationReminderEnabled
+        rotationReminderEnabled,
+        rotationReminderInterval
       };
       const { data } = await apiRequest.patch(`/api/v3/secrets/${secretName}`, reqBody);
       return data;

--- a/frontend/src/hooks/api/secrets/mutations.tsx
+++ b/frontend/src/hooks/api/secrets/mutations.tsx
@@ -142,7 +142,7 @@ export const useUpdateSecretV3 = ({
       newSecretName,
       skipMultilineEncoding,
       rotationReminderEnabled,
-      rotationReminderInterval
+      reminderIntervalInDays
     }) => {
       const PRIVATE_KEY = localStorage.getItem("PRIVATE_KEY") as string;
 
@@ -166,7 +166,7 @@ export const useUpdateSecretV3 = ({
         skipMultilineEncoding,
         secretName: newSecretName,
         rotationReminderEnabled,
-        rotationReminderInterval
+        reminderIntervalInDays
       };
       const { data } = await apiRequest.patch(`/api/v3/secrets/${secretName}`, reqBody);
       return data;

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -72,7 +72,8 @@ export const decryptSecrets = (
       createdAt: encSecret.createdAt,
       updatedAt: encSecret.updatedAt,
       version: encSecret.version,
-      skipMultilineEncoding: encSecret.skipMultilineEncoding
+      skipMultilineEncoding: encSecret.skipMultilineEncoding,
+      rotationReminderEnabled: encSecret.rotationReminderEnabled
     };
 
     if (encSecret.type === "personal") {

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -73,7 +73,8 @@ export const decryptSecrets = (
       updatedAt: encSecret.updatedAt,
       version: encSecret.version,
       skipMultilineEncoding: encSecret.skipMultilineEncoding,
-      rotationReminderEnabled: encSecret.rotationReminderEnabled
+      rotationReminderEnabled: encSecret.rotationReminderEnabled,
+      rotationReminderInterval: encSecret.rotationReminderInterval
     };
 
     if (encSecret.type === "personal") {

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -74,7 +74,7 @@ export const decryptSecrets = (
       version: encSecret.version,
       skipMultilineEncoding: encSecret.skipMultilineEncoding,
       rotationReminderEnabled: encSecret.rotationReminderEnabled,
-      rotationReminderInterval: encSecret.rotationReminderInterval
+      reminderIntervalInDays: encSecret.reminderIntervalInDays
     };
 
     if (encSecret.type === "personal") {

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -74,7 +74,8 @@ export const decryptSecrets = (
       version: encSecret.version,
       skipMultilineEncoding: encSecret.skipMultilineEncoding,
       rotationReminderEnabled: encSecret.rotationReminderEnabled,
-      reminderIntervalInDays: encSecret.reminderIntervalInDays
+      reminderIntervalInDays: encSecret.reminderIntervalInDays,
+      reminderNotes: encSecret.reminderNotes
     };
 
     if (encSecret.type === "personal") {

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -18,6 +18,7 @@ export type EncryptedSecret = {
   updatedAt: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   secretCommentCiphertext: string;
   secretCommentIV: string;
   secretCommentTag: string;
@@ -40,6 +41,7 @@ export type DecryptedSecret = {
   folderId?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
 };
 
 export type EncryptedSecretVersion = {
@@ -60,6 +62,7 @@ export type EncryptedSecretVersion = {
   __v: number;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
   createdAt: string;
   updatedAt: string;
 };
@@ -117,6 +120,7 @@ export type TUpdateSecretsV3DTO = {
   secretComment?: string;
   tags?: string[];
   rotationReminderEnabled?: boolean;
+  rotationReminderInterval?: number;
 };
 
 export type TDeleteSecretsV3DTO = {

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -17,6 +17,7 @@ export type EncryptedSecret = {
   createdAt: string;
   updatedAt: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   secretCommentCiphertext: string;
   secretCommentIV: string;
   secretCommentTag: string;
@@ -38,6 +39,7 @@ export type DecryptedSecret = {
   overrideAction?: string;
   folderId?: string;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
 };
 
 export type EncryptedSecretVersion = {
@@ -57,6 +59,7 @@ export type EncryptedSecretVersion = {
   tags: WsTag[];
   __v: number;
   skipMultilineEncoding?: boolean;
+  rotationReminderEnabled?: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -113,6 +116,7 @@ export type TUpdateSecretsV3DTO = {
   secretValue: string;
   secretComment?: string;
   tags?: string[];
+  rotationReminderEnabled?: boolean;
 };
 
 export type TDeleteSecretsV3DTO = {

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -18,7 +18,7 @@ export type EncryptedSecret = {
   updatedAt: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   secretCommentCiphertext: string;
   secretCommentIV: string;
   secretCommentTag: string;
@@ -41,7 +41,7 @@ export type DecryptedSecret = {
   folderId?: string;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
 };
 
 export type EncryptedSecretVersion = {
@@ -62,7 +62,7 @@ export type EncryptedSecretVersion = {
   __v: number;
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
   createdAt: string;
   updatedAt: string;
 };
@@ -120,7 +120,7 @@ export type TUpdateSecretsV3DTO = {
   secretComment?: string;
   tags?: string[];
   rotationReminderEnabled?: boolean;
-  rotationReminderInterval?: number;
+  reminderIntervalInDays?: number;
 };
 
 export type TDeleteSecretsV3DTO = {

--- a/frontend/src/hooks/api/secrets/types.ts
+++ b/frontend/src/hooks/api/secrets/types.ts
@@ -19,6 +19,7 @@ export type EncryptedSecret = {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   secretCommentCiphertext: string;
   secretCommentIV: string;
   secretCommentTag: string;
@@ -42,6 +43,7 @@ export type DecryptedSecret = {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
 };
 
 export type EncryptedSecretVersion = {
@@ -63,6 +65,7 @@ export type EncryptedSecretVersion = {
   skipMultilineEncoding?: boolean;
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
   createdAt: string;
   updatedAt: string;
 };
@@ -121,6 +124,7 @@ export type TUpdateSecretsV3DTO = {
   tags?: string[];
   rotationReminderEnabled?: boolean;
   reminderIntervalInDays?: number;
+  reminderNotes?: string;
 };
 
 export type TDeleteSecretsV3DTO = {

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -150,6 +150,7 @@ export const SecretDetailSidebar = ({
     } else {
       setValue("rotationReminderEnabled", false, { shouldDirty: true })
       setValue("reminderIntervalInDays", undefined)
+      setValue("reminderNotes", undefined)
     }
   };
 
@@ -378,20 +379,31 @@ export const SecretDetailSidebar = ({
                       Set secret rotation reminder
                     </Switch>
                     {rotationReminderEnabled && (
-                      <FormControl label="Rotation reminder interval in days" className="mt-4 mb-0">
-                        <Input
-                          type="number"
-                          pattern="[0-9]*"
-                          min="1"
-                          max="10000"
-                          step="1"
-                          defaultValue={30}
-                          isDisabled={!isAllowed}
-                          {...register("reminderIntervalInDays", {
-                            valueAsNumber: true
-                          })}
-                        />
-                      </FormControl>
+                      <>
+                        <FormControl label="Rotation reminder interval in days" className="mt-4 mb-0">
+                          <Input
+                            className="bg-bunker-800"
+                            type="number"
+                            pattern="[0-9]*"
+                            min="1"
+                            max="10000"
+                            step="1"
+                            defaultValue={30}
+                            isDisabled={!isAllowed}
+                            {...register("reminderIntervalInDays", {
+                              valueAsNumber: true
+                            })}
+                          />
+                        </FormControl>
+                        <FormControl label="Rotation reminder note" className="mt-4 mb-0">
+                          <TextArea
+                            className="border border-mineshaft-600 text-sm"
+                            {...register("reminderNotes")}
+                            readOnly={isReadOnly}
+                            rows={2}
+                          />
+                        </FormControl>
+                      </>
                     )}
                   </>
                 )}

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -143,6 +143,15 @@ export const SecretDetailSidebar = ({
     }
   };
 
+  const rotationReminderEnabled = watch("rotationReminderEnabled");
+  const handleEnableRotationReminder = (isEnabled: boolean) => {
+    if (isEnabled) {
+      setValue("rotationReminderEnabled", true, { shouldDirty: true })
+    } else {
+      setValue("rotationReminderEnabled", false, { shouldDirty: true })
+    }
+  };
+
   const handleFormSubmit = async (data: TFormSchema) => {
     await onSaveSecret(secret, { ...secret, ...data }, () => reset());
   };
@@ -321,7 +330,7 @@ export const SecretDetailSidebar = ({
                 rows={5}
               />
             </FormControl>
-            <div className="my-2 mb-6 border-b border-mineshaft-600 pb-4">
+            <div className="mb-4">
               <Controller
                 control={control}
                 name="skipMultilineEncoding"
@@ -351,6 +360,41 @@ export const SecretDetailSidebar = ({
                   </ProjectPermissionCan>
                 )}
               />
+            </div>
+            <div className="mb-2 border-b border-mineshaft-600 pb-4">
+              <ProjectPermissionCan
+                I={ProjectPermissionActions.Edit}
+                a={subject(ProjectPermissionSub.Secrets, { environment, secretPath })}
+              >
+                {(isAllowed) => (
+                  <>
+                    <Switch
+                      isDisabled={!isAllowed}
+                      id="enable-rotation-reminder"
+                      onCheckedChange={handleEnableRotationReminder}
+                      isChecked={rotationReminderEnabled}
+                    >
+                      Set secret rotation reminder
+                    </Switch>
+                    {/* TODO: add number input for numDays interval */}
+                    {/* {rotationReminderEnabled && (
+                      <Controller
+                        name="rotationReminder"
+                        control={control}
+                        render={({ field }) => (
+                          // <FormControl label="Reminder interval">
+                          //   <SecretInput
+                          //     isReadOnly={isReadOnly}
+                          //     containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-800  px-2 py-1.5"
+                          //     {...field}
+                          //   />
+                          // </FormControl>
+                        )}
+                      />
+                    )} */}
+                  </>
+                )}
+              </ProjectPermissionCan>
             </div>
             <div className="dark mb-4 text-sm text-bunker-300 flex-grow">
               <div className="mb-2">Version History</div>

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -149,8 +149,6 @@ export const SecretDetailSidebar = ({
       setValue("rotationReminderEnabled", true, { shouldDirty: true })
     } else {
       setValue("rotationReminderEnabled", false, { shouldDirty: true })
-      setValue("reminderIntervalInDays", undefined)
-      setValue("reminderNotes", undefined)
     }
   };
 

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -416,7 +416,7 @@ export const SecretDetailSidebar = ({
                 ))}
               </div>
             </div>
-            <div className="flex flex-col space-y-4">
+            <div className="flex flex-col space-y-4 pb-4">
               <div className="flex space-x-4 items-center">
                 <ProjectPermissionCan
                   I={ProjectPermissionActions.Edit}

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -149,6 +149,7 @@ export const SecretDetailSidebar = ({
       setValue("rotationReminderEnabled", true, { shouldDirty: true })
     } else {
       setValue("rotationReminderEnabled", false, { shouldDirty: true })
+      setValue("rotationReminderInterval", undefined)
     }
   };
 
@@ -376,22 +377,22 @@ export const SecretDetailSidebar = ({
                     >
                       Set secret rotation reminder
                     </Switch>
-                    {/* TODO: add number input for numDays interval */}
-                    {/* {rotationReminderEnabled && (
-                      <Controller
-                        name="rotationReminder"
-                        control={control}
-                        render={({ field }) => (
-                          // <FormControl label="Reminder interval">
-                          //   <SecretInput
-                          //     isReadOnly={isReadOnly}
-                          //     containerClassName="text-bunker-300 hover:border-primary-400/50 border border-mineshaft-600 bg-bunker-800  px-2 py-1.5"
-                          //     {...field}
-                          //   />
-                          // </FormControl>
-                        )}
-                      />
-                    )} */}
+                    {rotationReminderEnabled && (
+                      <FormControl label="Rotation reminder interval in days" className="mt-4 mb-0">
+                        <Input
+                          type="number"
+                          pattern="[0-9]*"
+                          min="1"
+                          max="10000"
+                          step="1"
+                          defaultValue={30}
+                          isDisabled={!isAllowed}
+                          {...register("rotationReminderInterval", {
+                            valueAsNumber: true
+                          })}
+                        />
+                      </FormControl>
+                    )}
                   </>
                 )}
               </ProjectPermissionCan>

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretDetaiSidebar.tsx
@@ -149,7 +149,7 @@ export const SecretDetailSidebar = ({
       setValue("rotationReminderEnabled", true, { shouldDirty: true })
     } else {
       setValue("rotationReminderEnabled", false, { shouldDirty: true })
-      setValue("rotationReminderInterval", undefined)
+      setValue("reminderIntervalInDays", undefined)
     }
   };
 
@@ -387,7 +387,7 @@ export const SecretDetailSidebar = ({
                           step="1"
                           defaultValue={30}
                           isDisabled={!isAllowed}
-                          {...register("rotationReminderInterval", {
+                          {...register("reminderIntervalInDays", {
                             valueAsNumber: true
                           })}
                         />

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
@@ -126,7 +126,8 @@ export const SecretListView = ({
       skipMultilineEncoding,
       newKey,
       secretId,
-      rotationReminderEnabled
+      rotationReminderEnabled,
+      rotationReminderInterval
     }: Partial<{
       value: string;
       comment: string;
@@ -135,6 +136,7 @@ export const SecretListView = ({
       newKey: string;
       secretId: string;
       rotationReminderEnabled: boolean;
+      rotationReminderInterval: number;
     }> = {}
   ) => {
     if (operation === "delete") {
@@ -163,7 +165,8 @@ export const SecretListView = ({
         secretComment: comment,
         skipMultilineEncoding,
         newSecretName: newKey,
-        rotationReminderEnabled
+        rotationReminderEnabled,
+        rotationReminderInterval
       });
       return;
     }
@@ -198,7 +201,7 @@ export const SecretListView = ({
       const oldTagIds = orgSecret.tags.map(({ _id }) => _id);
       const isSameTags = JSON.stringify(tagIds) === JSON.stringify(oldTagIds);
       const isSharedSecUnchanged =
-        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled"] as const).every(
+        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled", "rotationReminderInterval"] as const).every(
           (el) => orgSecret[el] === modSecret[el]
         ) && isSameTags;
 
@@ -228,7 +231,8 @@ export const SecretListView = ({
             secretId: orgSecret._id,
             newKey: hasKeyChanged ? key : undefined,
             skipMultilineEncoding: modSecret.skipMultilineEncoding,
-            rotationReminderEnabled: modSecret.rotationReminderEnabled
+            rotationReminderEnabled: modSecret.rotationReminderEnabled,
+            rotationReminderInterval: modSecret.rotationReminderInterval
           });
           if (cb) cb();
         }

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
@@ -127,7 +127,7 @@ export const SecretListView = ({
       newKey,
       secretId,
       rotationReminderEnabled,
-      rotationReminderInterval
+      reminderIntervalInDays
     }: Partial<{
       value: string;
       comment: string;
@@ -136,7 +136,7 @@ export const SecretListView = ({
       newKey: string;
       secretId: string;
       rotationReminderEnabled: boolean;
-      rotationReminderInterval: number;
+      reminderIntervalInDays: number;
     }> = {}
   ) => {
     if (operation === "delete") {
@@ -166,7 +166,7 @@ export const SecretListView = ({
         skipMultilineEncoding,
         newSecretName: newKey,
         rotationReminderEnabled,
-        rotationReminderInterval
+        reminderIntervalInDays
       });
       return;
     }
@@ -201,7 +201,7 @@ export const SecretListView = ({
       const oldTagIds = orgSecret.tags.map(({ _id }) => _id);
       const isSameTags = JSON.stringify(tagIds) === JSON.stringify(oldTagIds);
       const isSharedSecUnchanged =
-        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled", "rotationReminderInterval"] as const).every(
+        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled", "reminderIntervalInDays"] as const).every(
           (el) => orgSecret[el] === modSecret[el]
         ) && isSameTags;
 
@@ -232,7 +232,7 @@ export const SecretListView = ({
             newKey: hasKeyChanged ? key : undefined,
             skipMultilineEncoding: modSecret.skipMultilineEncoding,
             rotationReminderEnabled: modSecret.rotationReminderEnabled,
-            rotationReminderInterval: modSecret.rotationReminderInterval
+            reminderIntervalInDays: modSecret.reminderIntervalInDays
           });
           if (cb) cb();
         }

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
@@ -127,7 +127,8 @@ export const SecretListView = ({
       newKey,
       secretId,
       rotationReminderEnabled,
-      reminderIntervalInDays
+      reminderIntervalInDays,
+      reminderNotes
     }: Partial<{
       value: string;
       comment: string;
@@ -137,6 +138,7 @@ export const SecretListView = ({
       secretId: string;
       rotationReminderEnabled: boolean;
       reminderIntervalInDays: number;
+      reminderNotes: string;
     }> = {}
   ) => {
     if (operation === "delete") {
@@ -166,7 +168,8 @@ export const SecretListView = ({
         skipMultilineEncoding,
         newSecretName: newKey,
         rotationReminderEnabled,
-        reminderIntervalInDays
+        reminderIntervalInDays,
+        reminderNotes
       });
       return;
     }
@@ -201,7 +204,7 @@ export const SecretListView = ({
       const oldTagIds = orgSecret.tags.map(({ _id }) => _id);
       const isSameTags = JSON.stringify(tagIds) === JSON.stringify(oldTagIds);
       const isSharedSecUnchanged =
-        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled", "reminderIntervalInDays"] as const).every(
+        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled", "reminderIntervalInDays", "reminderNotes"] as const).every(
           (el) => orgSecret[el] === modSecret[el]
         ) && isSameTags;
 
@@ -232,7 +235,8 @@ export const SecretListView = ({
             newKey: hasKeyChanged ? key : undefined,
             skipMultilineEncoding: modSecret.skipMultilineEncoding,
             rotationReminderEnabled: modSecret.rotationReminderEnabled,
-            reminderIntervalInDays: modSecret.reminderIntervalInDays
+            reminderIntervalInDays: modSecret.reminderIntervalInDays,
+            reminderNotes: modSecret.reminderNotes
           });
           if (cb) cb();
         }

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.tsx
@@ -125,7 +125,8 @@ export const SecretListView = ({
       tags,
       skipMultilineEncoding,
       newKey,
-      secretId
+      secretId,
+      rotationReminderEnabled
     }: Partial<{
       value: string;
       comment: string;
@@ -133,6 +134,7 @@ export const SecretListView = ({
       skipMultilineEncoding: boolean;
       newKey: string;
       secretId: string;
+      rotationReminderEnabled: boolean;
     }> = {}
   ) => {
     if (operation === "delete") {
@@ -160,7 +162,8 @@ export const SecretListView = ({
         tags,
         secretComment: comment,
         skipMultilineEncoding,
-        newSecretName: newKey
+        newSecretName: newKey,
+        rotationReminderEnabled
       });
       return;
     }
@@ -195,7 +198,7 @@ export const SecretListView = ({
       const oldTagIds = orgSecret.tags.map(({ _id }) => _id);
       const isSameTags = JSON.stringify(tagIds) === JSON.stringify(oldTagIds);
       const isSharedSecUnchanged =
-        (["key", "value", "comment", "skipMultilineEncoding"] as const).every(
+        (["key", "value", "comment", "skipMultilineEncoding", "rotationReminderEnabled"] as const).every(
           (el) => orgSecret[el] === modSecret[el]
         ) && isSameTags;
 
@@ -224,7 +227,8 @@ export const SecretListView = ({
             comment,
             secretId: orgSecret._id,
             newKey: hasKeyChanged ? key : undefined,
-            skipMultilineEncoding: modSecret.skipMultilineEncoding
+            skipMultilineEncoding: modSecret.skipMultilineEncoding,
+            rotationReminderEnabled: modSecret.rotationReminderEnabled
           });
           if (cb) cb();
         }

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
@@ -28,7 +28,8 @@ export const formSchema = z.object({
       tagColor: z.string().optional()
     })
     .array()
-    .default([])
+    .default([]),
+  rotationReminderEnabled: z.boolean().optional()
 });
 
 export type TFormSchema = z.infer<typeof formSchema>;

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
@@ -30,7 +30,8 @@ export const formSchema = z.object({
     .array()
     .default([]),
   rotationReminderEnabled: z.boolean().optional(),
-  reminderIntervalInDays: z.number().optional()
+  reminderIntervalInDays: z.number().optional(),
+  reminderNotes: z.string().trim().optional()
 });
 
 export type TFormSchema = z.infer<typeof formSchema>;

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
@@ -29,7 +29,8 @@ export const formSchema = z.object({
     })
     .array()
     .default([]),
-  rotationReminderEnabled: z.boolean().optional()
+  rotationReminderEnabled: z.boolean().optional(),
+  rotationReminderInterval: z.number().optional()
 });
 
 export type TFormSchema = z.infer<typeof formSchema>;

--- a/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
+++ b/frontend/src/views/SecretMainPage/components/SecretListView/SecretListView.utils.ts
@@ -30,7 +30,7 @@ export const formSchema = z.object({
     .array()
     .default([]),
   rotationReminderEnabled: z.boolean().optional(),
-  rotationReminderInterval: z.number().optional()
+  reminderIntervalInDays: z.number().optional()
 });
 
 export type TFormSchema = z.infer<typeof formSchema>;


### PR DESCRIPTION
# Description 📣

Added a feature for users to add reminders for rotating secrets. Reminders are sent through email to all project members. Reminders can be added to a specific secret with customizable reminder intervals and notes.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Go to secret sidebar to set a reminder along with its interval and note. Hit save.
![image](https://github.com/Winggo/infisical-assessment/assets/26425671/c8de07b7-f091-49a7-a90e-ace491aed46e)

And receive an email with the reminder note when the time comes!
![image](https://github.com/Winggo/infisical-assessment/assets/26425671/1d429d79-f855-4ed5-95da-3beefdd4b813)


---

- [ ] I have read the [contributing guide](https://infisical.com/docs/contributing/overview), agreed and acknowledged the [code of conduct](https://infisical.com/docs/contributing/code-of-conduct). 📝